### PR TITLE
wpa_supplicant: skip compiling preauth.c and pmksa_cache.c

### DIFF
--- a/wpa_supplicant/Makefile
+++ b/wpa_supplicant/Makefile
@@ -151,8 +151,8 @@ endif
 
 ifndef CONFIG_NO_WPA
 OBJS += ../src/rsn_supp/wpa.o
-OBJS += ../src/rsn_supp/preauth.o
-OBJS += ../src/rsn_supp/pmksa_cache.o
+#OBJS += ../src/rsn_supp/preauth.o
+#OBJS += ../src/rsn_supp/pmksa_cache.o
 #OBJS += ../src/rsn_supp/peerkey.o
 OBJS += ../src/rsn_supp/wpa_ie.o
 OBJS += ../src/common/wpa_common.o


### PR DESCRIPTION
Signed-off-by: Kelvin Cheung keguang.zhang@gmail.com
