### PR TITLE
wpa_supplicant: Use CONFIG_L2_PACKET to skip compiling l2_packet_none.c

### DIFF
--- a/wpa_supplicant/Makefile
+++ b/wpa_supplicant/Makefile
@@ -208,11 +208,11 @@ LDFLAGS += $(DRV_WPA_LDFLAGS)
 LIBS += $(DRV_WPA_LIBS)
 endif
 
-ifndef CONFIG_L2_PACKET
-CONFIG_L2_PACKET=linux
-endif
+#ifndef CONFIG_L2_PACKET
+#CONFIG_L2_PACKET=linux
+#endif
 
-OBJS_l2 += ../src/l2_packet/l2_packet_$(CONFIG_L2_PACKET).o
+#OBJS_l2 += ../src/l2_packet/l2_packet_$(CONFIG_L2_PACKET).o
 
 ifeq ($(CONFIG_L2_PACKET), pcap)
 ifdef CONFIG_WINPCAP

--- a/wpa_supplicant/defconfig
+++ b/wpa_supplicant/defconfig
@@ -294,7 +294,7 @@ CONFIG_ELOOP=eloop_none
 # winpcap = WinPcap with receive thread
 # ndis = Windows NDISUIO (note: requires CONFIG_USE_NDISUIO=y)
 # none = Empty template
-CONFIG_L2_PACKET=none
+#CONFIG_L2_PACKET=none
 
 # PeerKey handshake for Station to Station Link (IEEE 802.11e DLS)
 #CONFIG_PEERKEY=y

--- a/wpa_supplicant/events.c
+++ b/wpa_supplicant/events.c
@@ -944,8 +944,10 @@ static void wpa_supplicant_event_assoc(struct wpa_supplicant *wpa_s,
 	wpa_msg(wpa_s, MSG_INFO, "Associated with " MACSTR, MAC2STR(bssid));
 
 	wpa_sm_notify_assoc(wpa_s->wpa, bssid);
+#ifdef CONFIG_L2_PACKET
 	if (wpa_s->l2)
 		l2_packet_notify_auth_start(wpa_s->l2);
+#endif /* CONFIG_L2_PACKET */
 
 	/*
 	 * Set portEnabled first to FALSE in order to get EAP state machine out

--- a/wpa_supplicant/wpa_supplicant.c
+++ b/wpa_supplicant/wpa_supplicant.c
@@ -293,8 +293,10 @@ void wpa_supplicant_set_non_wpa_policy(struct wpa_supplicant *wpa_s,
 static void wpa_supplicant_cleanup(struct wpa_supplicant *wpa_s)
 {
 
+#ifdef CONFIG_L2_PACKET
 	l2_packet_deinit(wpa_s->l2);
 	wpa_s->l2 = NULL;
+#endif /* CONFIG_L2_PACKET */
 
 
 	if (wpa_s->conf != NULL) {
@@ -1510,6 +1512,7 @@ int wpa_supplicant_driver_init(struct wpa_supplicant *wpa_s)
 		const u8 *addr = wpa_drv_get_mac_addr(wpa_s);
 		if (addr)
 			os_memcpy(wpa_s->own_addr, addr, ETH_ALEN);
+#ifdef CONFIG_L2_PACKET
 	} else if (!(wpa_s->drv_flags &
 		     WPA_DRIVER_FLAGS_P2P_DEDICATED_INTERFACE)) {
 		wpa_s->l2 = l2_packet_init(wpa_s->ifname,
@@ -1518,16 +1521,19 @@ int wpa_supplicant_driver_init(struct wpa_supplicant *wpa_s)
 					   wpa_supplicant_rx_eapol, wpa_s, 0);
 		if (wpa_s->l2 == NULL)
 			return -1;
+#endif /* CONFIG_L2_PACKET */
 	} else {
 		const u8 *addr = wpa_drv_get_mac_addr(wpa_s);
 		if (addr)
 			os_memcpy(wpa_s->own_addr, addr, ETH_ALEN);
 	}
 
+#ifdef CONFIG_L2_PACKET
 	if (wpa_s->l2 && l2_packet_get_own_addr(wpa_s->l2, wpa_s->own_addr)) {
 		wpa_printf(MSG_ERROR, "Failed to get own L2 address");
 		return -1;
 	}
+#endif /* CONFIG_L2_PACKET */
 
 	wpa_printf(MSG_DEBUG, "Own MAC address: " MACSTR,
 		   MAC2STR(wpa_s->own_addr));

--- a/wpa_supplicant/wpas_glue.c
+++ b/wpa_supplicant/wpas_glue.c
@@ -99,9 +99,11 @@ static u8 * wpa_alloc_eapol(const struct wpa_supplicant *wpa_s, u8 type,
 static int wpa_ether_send(struct wpa_supplicant *wpa_s, const u8 *dest,
 			  u16 proto, const u8 *buf, size_t len)
 {
+#ifdef CONFIG_L2_PACKET
 	if (wpa_s->l2) {
 		return l2_packet_send(wpa_s->l2, dest, proto, buf, len);
 	}
+#endif /* CONFIG_L2_PACKET */
 
 	return wpa_drv_send_eapol(wpa_s, dest, proto, buf, len);
 }


### PR DESCRIPTION
Signed-off-by: Kelvin Cheung keguang.zhang@gmail.com
